### PR TITLE
ログを外部に書き出すためのfilter追加

### DIFF
--- a/app-log.php
+++ b/app-log.php
@@ -3,7 +3,7 @@
 Plugin Name: App Log
 Plugin URI:
 Description: A simple logger for debugging.
-Version: 1.1.1
+Version: 1.1.2
 Author: PRESSMAN
 Author URI: https://www.pressman.ne.jp/
 Text Domain: aplg

--- a/classes/class-aplg-logger.php
+++ b/classes/class-aplg-logger.php
@@ -64,6 +64,12 @@ class Aplg_Logger {
 
 		// Write to file
 		$log_file = realpath( $log_dir ) . '/' . $filename;
+
+		$pre = apply_filters( 'pre_applog_write', null, $log_message, $message, $log_level, $log_file );
+		if ( ! is_null( $pre ) ) {
+			return;
+		}
+
 		$fp       = fopen( $log_file, 'a' );
 		fwrite( $fp, $log_message );
 		fclose( $fp );

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: pressmaninc, hiroshisekiguchi, kazunao, muraokashotaro, razelpaldo
 Tags: pressman, debug, log
 Requires at least: 5.2.2
-Tested up to: 5.4.2
+Tested up to: 5.6
 Requires PHP: 5.6.20
-Stable tag:　1.1.1
+Stable tag:　1.1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -20,6 +20,9 @@ By default, log files are stored in */wp-content/plugins/app-log/applog* but log
 2. Activate the plugin through the Plugins menu in WordPress.
 
 == Changelog ==
+= 1.1.2 =
+* add hook 'pre_applog_write'
+
 = 1.1.1 =
 * bug fix on warning message displayed during password reset
 * updated Japanese translation and some field labels


### PR DESCRIPTION
サーバレス環境で使用するために、ログを書き出す直前にhookで別ロジックを登録できるようhookを追加しました。
それに伴いバージョンの更新をしています。

また、ついでに最新のWPで動作確認を行ったのでテスト済みバージョンを最新版に変更しています。