### PR TITLE
Feature/add auto delete log files

### DIFF
--- a/admin/aplg-dashboard.php
+++ b/admin/aplg-dashboard.php
@@ -39,6 +39,15 @@ class Aplg_Dashboard {
 	 * Displays log file list & links in dashboard
 	 */
 	public function add_dashboard_widget() {
+		// Check if widget should be displayed
+		$is_widget_show = true;
+		if (defined('APPLOG_DASHBOARD_WIDGET_SHOW')) {
+			$is_widget_show = APPLOG_DASHBOARD_WIDGET_SHOW;
+		}
+		if (!$is_widget_show) {
+			return;
+		}
+		
 		if ( ! current_user_can( 'administrator' ) ) {
 			return;
 		}

--- a/admin/aplg-dashboard.php
+++ b/admin/aplg-dashboard.php
@@ -40,14 +40,10 @@ class Aplg_Dashboard {
 	 */
 	public function add_dashboard_widget() {
 		// Check if widget should be displayed
-		$is_widget_show = true;
-		if (defined('APPLOG_DASHBOARD_WIDGET_SHOW')) {
-			$is_widget_show = APPLOG_DASHBOARD_WIDGET_SHOW;
-		}
-		if (!$is_widget_show) {
+		if ( defined( 'APPLOG_DASHBOARD_WIDGET_HIDE' ) &&  true === APPLOG_DASHBOARD_WIDGET_HIDE ) {
 			return;
 		}
-		
+				
 		if ( ! current_user_can( 'administrator' ) ) {
 			return;
 		}

--- a/admin/aplg-settings.php
+++ b/admin/aplg-settings.php
@@ -138,6 +138,10 @@ class Aplg_Settings {
 	 * @return int
 	 */
 	public static function get_log_lifetime() {
+		// Global variable APPLOG_AUTO_DELETE_MAX_LIFETIME can be used to override the default value
+		if (defined('APPLOG_AUTO_DELETE_MAX_LIFETIME')) {
+			return APPLOG_AUTO_DELETE_MAX_LIFETIME;
+		}
 		return self::LOG_AUTO_DELETE_MAX_LIFETIME;
 	}
 }

--- a/app-log.php
+++ b/app-log.php
@@ -61,11 +61,18 @@ class App_Log {
 	public function set_applog_options() {
 		$option = get_option( 'aplg_settings' );
 		if ( ! $option ) {
-			$default_settings = array(
-				'log_directory' => Aplg_Settings::get_path_to_logdir(),
-				'enable_disable_maillog' => 0,
-			);
-			update_option( 'aplg_settings', $default_settings );
+		
+			$default_settings = array();
+
+			if (defined('APPLOG_LOG_DIR')) {
+				$default_settings['log_directory'] = APPLOG_LOG_DIR;
+			} else {
+				$default_settings['log_directory'] = Aplg_Settings::get_path_to_logdir();
+			}
+
+			$default_settings['enable_disable_maillog'] = 0;
+
+			update_option('aplg_settings', $default_settings);
 		}
 	}
 

--- a/app-log.php
+++ b/app-log.php
@@ -61,13 +61,13 @@ class App_Log {
 	public function set_applog_options() {
 		$option = get_option( 'aplg_settings' );
 		if ( ! $option ) {
-		
-			$default_settings = array();
+			$default_settings = array(
+				'log_directory' => Aplg_Settings::get_path_to_logdir(),
+				'enable_disable_maillog' => 0,
+			);
 
-			if (defined('APPLOG_LOG_DIR')) {
+			if ( defined( 'APPLOG_LOG_DIR' ) ) {
 				$default_settings['log_directory'] = APPLOG_LOG_DIR;
-			} else {
-				$default_settings['log_directory'] = Aplg_Settings::get_path_to_logdir();
 			}
 
 			$default_settings['enable_disable_maillog'] = 0;

--- a/classes/class-aplg-logger.php
+++ b/classes/class-aplg-logger.php
@@ -38,7 +38,7 @@ class Aplg_Logger {
 			$message = print_r( $message, true );
 		}
 
-		$log_message = '[' . format_date_by_wp_version( 'Y-m-d H:i:s' ) . '] [' . str_pad( $log_level, 5, ' ' ) . '] ';
+		$log_message = '[' . self::format_date_by_wp_version( 'Y-m-d H:i:s' ) . '] [' . str_pad( $log_level, 5, ' ' ) . '] ';
 		$process_id  = getmypid();
 		if ( $process_id ) {
 			$log_message .= '(Process ID: ' . $process_id . ') ';
@@ -59,11 +59,11 @@ class Aplg_Logger {
 			$log_file_ext = self::ALLOWED_FILE_EXT['LOG'];
 		}
 
-		$filename = format_date_by_wp_version( 'Ymd' ) . $log_file_ext;
+		$filename = self::format_date_by_wp_version( 'Ymd' ) . $log_file_ext;
 
 		// If the file name format is specified in the constant, use it
 		if (defined('APPLOG_FILENAME_FORMAT')) {
-			$filename = format_date_by_wp_version( APPLOG_FILENAME_FORMAT ) . $log_file_ext;
+			$filename = self::format_date_by_wp_version( APPLOG_FILENAME_FORMAT ) . $log_file_ext;
 		}
 
 		$log_dir  = Aplg_Settings::get_path_to_logdir( $dirname );
@@ -148,11 +148,11 @@ class Aplg_Logger {
 		}
 	}
 
-	private function format_date_by_wp_version($format = 'Y-m-d H:i:s') {
-		if ( version_compare( $GLOBALS['wp_version'], '5.3', '<' ) ) {
-			return date_i18n( $format );
+	public static function format_date_by_wp_version($format) {
+		if ( version_compare($GLOBALS['wp_version'], '5.3', '<' ) ) {
+			return date_i18n($format);
 		} else {
-			return wp_date( $format );
+			return wp_date($format);
 		}
 	}
 }

--- a/classes/class-aplg-logger.php
+++ b/classes/class-aplg-logger.php
@@ -54,6 +54,11 @@ class Aplg_Logger {
 
 		$filename = date_i18n( 'Ymd' ) . $log_file_ext;
 		$log_dir  = Aplg_Settings::get_path_to_logdir( $dirname );
+		
+		// set log directory from global variable
+		if (define('APPLOG_LOG_DIR')) {
+			$log_dir = APPLOG_LOG_FILE_NAME;
+		}
 
 		// Create directory if it doesn't exist
 		if ( realpath( $log_dir ) === false || ! is_dir( $log_dir ) ) {

--- a/classes/class-aplg-logger.php
+++ b/classes/class-aplg-logger.php
@@ -54,11 +54,6 @@ class Aplg_Logger {
 
 		$filename = date_i18n( 'Ymd' ) . $log_file_ext;
 		$log_dir  = Aplg_Settings::get_path_to_logdir( $dirname );
-		
-		// set log directory from global variable
-		if (define('APPLOG_LOG_DIR')) {
-			$log_dir = APPLOG_LOG_FILE_NAME;
-		}
 
 		// Create directory if it doesn't exist
 		if ( realpath( $log_dir ) === false || ! is_dir( $log_dir ) ) {

--- a/classes/class-aplg-logger.php
+++ b/classes/class-aplg-logger.php
@@ -38,7 +38,7 @@ class Aplg_Logger {
 			$message = print_r( $message, true );
 		}
 
-		$log_message = '[' . date_i18n( 'Y-m-d H:i:s' ) . '] [' . str_pad( $log_level, 5, ' ' ) . '] ';
+		$log_message = '[' . format_date_by_wp_version( 'Y-m-d H:i:s' ) . '] [' . str_pad( $log_level, 5, ' ' ) . '] ';
 		$process_id  = getmypid();
 		if ( $process_id ) {
 			$log_message .= '(Process ID: ' . $process_id . ') ';
@@ -59,11 +59,11 @@ class Aplg_Logger {
 			$log_file_ext = self::ALLOWED_FILE_EXT['LOG'];
 		}
 
-		$filename = date_i18n( 'Ymd' ) . $log_file_ext;
+		$filename = format_date_by_wp_version( 'Ymd' ) . $log_file_ext;
 
 		// If the file name format is specified in the constant, use it
 		if (defined('APPLOG_FILENAME_FORMAT')) {
-			$filename = date_i18n( APPLOG_FILENAME_FORMAT ) . $log_file_ext;
+			$filename = format_date_by_wp_version( APPLOG_FILENAME_FORMAT ) . $log_file_ext;
 		}
 
 		$log_dir  = Aplg_Settings::get_path_to_logdir( $dirname );
@@ -145,6 +145,14 @@ class Aplg_Logger {
 				'type'    => 'error',
 				'message' => __( 'Failed to delete log.', 'aplg' ),
 			);
+		}
+	}
+
+	private function format_date_by_wp_version($format = 'Y-m-d H:i:s') {
+		if ( version_compare( $GLOBALS['wp_version'], '5.3', '<' ) ) {
+			return date_i18n( $format );
+		} else {
+			return wp_date( $format );
 		}
 	}
 }

--- a/classes/class-aplg-logger.php
+++ b/classes/class-aplg-logger.php
@@ -44,7 +44,14 @@ class Aplg_Logger {
 			$log_message .= '(Process ID: ' . $process_id . ') ';
 		}
 		$log_message .= $message . "\n";
+		
 		$log_file_ext = apply_filters( 'app_log_file_ext', self::ALLOWED_FILE_EXT['LOG'] );
+
+		// If the extension is specified in the constant, use it
+		if (defined('APPLOG_FILE_EXTENTION')) {
+			$log_file_ext = apply_filters( 'app_log_file_ext', self::ALLOWED_FILE_EXT[APPLOG_FILE_EXTENTION] );
+		}
+
 		if ( strpos( $log_file_ext, '.' ) !== 0 ) {
 			$log_file_ext = '.' . $log_file_ext;
 		}
@@ -53,6 +60,12 @@ class Aplg_Logger {
 		}
 
 		$filename = date_i18n( 'Ymd' ) . $log_file_ext;
+
+		// If the file name format is specified in the constant, use it
+		if (defined('APPLOG_FILENAME_FORMAT')) {
+			$filename = date_i18n( APPLOG_FILENAME_FORMAT ) . $log_file_ext;
+		}
+
 		$log_dir  = Aplg_Settings::get_path_to_logdir( $dirname );
 
 		// Create directory if it doesn't exist


### PR DESCRIPTION
https://pm1932.backlog.jp/view/KINGSMAN-322

wp-config.php に追加する必要

```
define('APPLOG_LOG_DIR',  '/var/www/app/html/wp-content/mu-plugins/log/'); //Kingman現行ままのLog Dir
define('APPLOG_AUTO_DELETE_MAX_LIFETIME', 7 * 24 * 60 * 60); //有効期限が一週間
define('APPLOG_DASHBOARD_WIDGET_SHOW',false); //Widget非表示
define('APPLOG_FILE_EXTENTION', 'txt'); //Log拡張子
define('APPLOG_FILENAME_FORMAT', 'Y-m-d'); //ファイル名フォーマット
```